### PR TITLE
Created Issue Templates on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report of the bug you discovered
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+<!--- COMPLETE ALL SECTIONS RELEVANT TO THIS ISSUE *-->
+
+### Describe The Bug
+*A clear and concise description of what the bug is.*
+
+### Steps To Reproduce:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error '....'
+
+### Expected Behavior
+*A clear and concise description of what you expected to happen.*
+
+### Screenshots
+*If applicable, add screenshots to help explain the problem.*
+
+### Additional Context
+*Add any other context about the problem here.*
+
+<!--- REMOVE IRRELEVANT/UNUSED SECTIONS BEFORE SUBMITTING THIS ISSUE *-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[REQUEST]"
+labels: ''
+assignees: ''
+
+---
+
+<!-- ! REMOVE IRRELEVANT/UNUSED SECTIONS BEFORE SUBMITTING THIS ISSUE -->
+
+<!-- **** Required **** -->
+### Current Behavior or Problem
+*A clear and concise description of the current behavior,*
+*`e.g., The Foundations Session exercises are difficult to maintain because '...'`*
+
+
+
+<!-- **** Required **** -->
+### Proposed Changes
+*A clear and concise description of what you want to happen,*
+*`e.g., I want to connect CodeSandbox to GitHub because '...'`*
+
+
+### Supports
+*Link all supported issues.*
+
+#_IssueId_
+
+### Alternatives Considered
+*A clear and concise description of any alternatives you've considered.*
+
+
+### Additional Context
+*Add any other context about the problem, proposed changes, or alternatives here.*
+
+
+<!-- ! REMOVE IRRELEVANT/UNUSED SECTIONS BEFORE SUBMITTING THIS ISSUE -->


### PR DESCRIPTION
Trying to configure repo to support using multiple different types of Issue Templates. 
[Followed the first few instructions found here.](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)

Created Bug report template and Feature request template.

